### PR TITLE
Clean up

### DIFF
--- a/src/com/microsoft/azure/shortcuts/common/Refreshable.java
+++ b/src/com/microsoft/azure/shortcuts/common/Refreshable.java
@@ -19,7 +19,7 @@
 */
 package com.microsoft.azure.shortcuts.common;
 
-// Reprepresents refreshable objecta
+// Reprepresents refreshable objects
 public interface Refreshable<T> {
 	T refresh() throws Exception;
 }

--- a/src/com/microsoft/azure/shortcuts/common/implementation/Utils.java
+++ b/src/com/microsoft/azure/shortcuts/common/implementation/Utils.java
@@ -45,8 +45,12 @@ import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class Utils {
-	
+public final class Utils {
+
+	private Utils() {
+		throw new AssertionError("Class should not be instantiated.");
+	}
+
 	// Create a new self-signed public/private key pair for an X.509 certificate packaged inside a PKCS#12 (PFX) file
 	public static File createCertPkcs12(
 			File targetPfxFile, 
@@ -175,7 +179,7 @@ public class Utils {
 	
 	
 	// Returns the first node matching the xpath in the xml
-	static public Node findXMLNode(String xml, String xpath) throws XPathExpressionException {
+	public static Node findXMLNode(String xml, String xpath) throws XPathExpressionException {
 		final InputSource parentSource = new InputSource(new StringReader(xml));
 		final XPath xpathObject = XPathFactory.newInstance().newXPath();
 		return (Node) xpathObject.evaluate(xpath, parentSource, XPathConstants.NODE);
@@ -196,7 +200,7 @@ public class Utils {
 	
 	
 	// Returns the XML document as a string
-	static String XMLtoString(Document doc) {
+	public static String XMLtoString(Document doc) {
 		try {
 			Transformer transformer = TransformerFactory.newInstance().newTransformer();
 			StringWriter writer = new StringWriter();

--- a/src/com/microsoft/azure/shortcuts/resources/AvailabilitySet.java
+++ b/src/com/microsoft/azure/shortcuts/resources/AvailabilitySet.java
@@ -38,14 +38,14 @@ public interface AvailabilitySet extends
 	 */
 	List<String> virtualMachineIds();
 	
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		GroupResourceBase.DefinitionWithRegion<DefinitionWithGroup> {
 	}
 	
-	public interface DefinitionWithGroup extends 
+	interface DefinitionWithGroup extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionProvisionable> {}
 	
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionProvisionable>,
 		GroupResourceBase.DefinitionWithTags<DefinitionProvisionable>,
 		Provisionable<AvailabilitySet> {	

--- a/src/com/microsoft/azure/shortcuts/resources/LoadBalancer.java
+++ b/src/com/microsoft/azure/shortcuts/resources/LoadBalancer.java
@@ -35,24 +35,24 @@ public interface LoadBalancer extends
 	/**
 	 * A new blank load balancer definition
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		GroupResourceBase.DefinitionWithRegion<DefinitionWithGroup> { }
 	
-	public interface DefinitionWithGroup extends
+	interface DefinitionWithGroup extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionWithFrontEnd> {}
 	
 	/**
 	 * A load balancer definition allowing to specify a front end IP address
 	 */
-	public interface DefinitionWithFrontEnd extends
+	interface DefinitionWithFrontEnd extends
 		DefinitionCombos.WithPublicIpAddress<DefinitionProvisionable> {
 	}
 	
 	/**
 	 * A load balancer definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	
-	public interface DefinitionProvisionable extends 
+
+	interface DefinitionProvisionable extends
 		Provisionable<LoadBalancer>,
 		GroupResourceBase.DefinitionWithTags<DefinitionProvisionable> {
 	}

--- a/src/com/microsoft/azure/shortcuts/resources/Network.java
+++ b/src/com/microsoft/azure/shortcuts/resources/Network.java
@@ -45,17 +45,17 @@ public interface Network extends
 	/**
 	 * A new blank virtual network definition
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		GroupResourceBase.DefinitionWithRegion<DefinitionWithGroup> { }
 	
-	public interface DefinitionWithGroup extends
+	interface DefinitionWithGroup extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionProvisionable> {}
 		
 	
 	/**
 	 * A virtual network definition expecting at least one subnet to be specified
 	 */
-	public interface DefinitionWithSubnet {
+	interface DefinitionWithSubnet {
 		DefinitionProvisionableWithSubnet withSubnet(String name, String cidr);
 		DefinitionProvisionableWithSubnet withSubnets(Map<String, String> nameCidrPairs);
 	}
@@ -63,34 +63,34 @@ public interface Network extends
 	/**
 	 * A virtual network definition expecting the network's address space to be specified
 	 */
-	public interface DefinitionWithAddressSpace {
+	interface DefinitionWithAddressSpace {
 		DefinitionProvisionableWithSubnet withAddressSpace(String cidr);
 	}
 	
 	/**
 	 * A virtual network definition expecting the IP address of an existing DNS server to be associated with the network 
 	 */
-	public interface DefinitionWithDNSServer {
+	interface DefinitionWithDNSServer {
 		DefinitionProvisionable withDnsServer(String ipAddress);
 	}
 	
 	/**
 	 * A new virtual network definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		Provisionable<Network>,
 		DefinitionWithAddressSpace,
 		DefinitionWithDNSServer,
 		GroupResourceBase.DefinitionWithTags<DefinitionProvisionable> {
 	}
 	
-	public interface DefinitionProvisionableWithSubnet extends 
+	interface DefinitionProvisionableWithSubnet extends
 		DefinitionProvisionable,
 		DefinitionWithSubnet { 
 	}
 	
 	
-	public interface Subnet extends Indexable, Wrapper<com.microsoft.azure.management.network.models.Subnet> {
+	interface Subnet extends Indexable, Wrapper<com.microsoft.azure.management.network.models.Subnet> {
 		String addressPrefix();
 		String networkSecurityGroup();
 	}

--- a/src/com/microsoft/azure/shortcuts/resources/NetworkInterface.java
+++ b/src/com/microsoft/azure/shortcuts/resources/NetworkInterface.java
@@ -39,45 +39,45 @@ public interface NetworkInterface extends
 	/**
 	 * A new blank network interface definition
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		GroupResourceBase.DefinitionWithRegion<DefinitionWithGroup> {
 	}
 	
 	/**
 	 * A network interface definition allowing to specify a group to associate with it
 	 */
-	public interface DefinitionWithGroup extends
+	interface DefinitionWithGroup extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionWithNetwork> {}
 	
 	/**
 	 * A network interface definition allowing to associate a virtual network with the network interface
 	 */
-	public interface DefinitionWithNetwork extends 
+	interface DefinitionWithNetwork extends
 		DefinitionCombos.WithExistingNetwork<DefinitionWithSubnet>,
 		DefinitionCombos.WithNewNetwork<DefinitionWithPrivateIp> {}
 	
 	/**
 	 * A network interface definition allowing to specify a subnet from the selected network to associate the network interface with
 	 */
-	public interface DefinitionWithSubnet extends 
+	interface DefinitionWithSubnet extends
 		DefinitionCombos.WithSubnet<DefinitionWithPrivateIp> {}
 	
 	/**
 	 * A network interface definition allowing to assign a private IP address within an existing virtual network subnet
 	 */
-	public interface DefinitionWithPrivateIp extends 
+	interface DefinitionWithPrivateIp extends
 		DefinitionCombos.WithPrivateIpAddress<DefinitionWithPublicIpAddress> {}	
 	
 	/**
 	 * A network interface definition allowing to associate it with a public IP address
 	 */
-	public interface DefinitionWithPublicIpAddress extends 
+	interface DefinitionWithPublicIpAddress extends
 		DefinitionCombos.WithPublicIpAddress<DefinitionProvisionable> { }	
 	
 	/**
 	 * A network interface definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		Provisionable<NetworkInterface>,
 		GroupResourceBase.DefinitionWithTags<DefinitionProvisionable> {
 	}

--- a/src/com/microsoft/azure/shortcuts/resources/NetworkSecurityGroup.java
+++ b/src/com/microsoft/azure/shortcuts/resources/NetworkSecurityGroup.java
@@ -34,19 +34,19 @@ public interface NetworkSecurityGroup extends
 	/**
 	 * A new blank NSG definition
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		GroupResourceBase.DefinitionWithRegion<DefinitionWithGroup> {}
 	
 	/**
 	 * An NSG definition allowing to specify the resource group to include it in.
 	 */
-	public interface DefinitionWithGroup extends
+	interface DefinitionWithGroup extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionProvisionable> {}
 	
 	/**
 	 * A public IP address definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		Provisionable<NetworkSecurityGroup>,
 		GroupResourceBase.DefinitionWithTags<DefinitionProvisionable> {
 		

--- a/src/com/microsoft/azure/shortcuts/resources/Provider.java
+++ b/src/com/microsoft/azure/shortcuts/resources/Provider.java
@@ -35,7 +35,7 @@ public interface Provider extends
 	Map<String, ResourceType> resourceTypes() throws Exception;
 	ResourceType resourceTypes(String name) throws Exception;
 
-	public interface ResourceType extends Indexable {
+	interface ResourceType extends Indexable {
 		List<String> apiVersions();
 		String latestApiVersion();
 	}

--- a/src/com/microsoft/azure/shortcuts/resources/PublicIpAddress.java
+++ b/src/com/microsoft/azure/shortcuts/resources/PublicIpAddress.java
@@ -40,19 +40,19 @@ public interface PublicIpAddress extends
 	/**
 	 * A new blank public IP address definition
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		GroupResourceBase.DefinitionWithRegion<DefinitionWithGroup> {}
 	
 	/**
 	 * A public IP address definition allowing to specify the resource group to include it in.
 	 */
-	public interface DefinitionWithGroup extends
+	interface DefinitionWithGroup extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionProvisionable> {}
 	
 	/**
 	 * A public IP address definition allowing to specify the IP address allocation method and a static IP address, if needed
 	 */
-	public interface DefinitionWithIpAddress {
+	interface DefinitionWithIpAddress {
 		/**
 		 * Enables static IP address allocation. The actual IP address allocated for this resource by Azure can be obtained 
 		 * after the provisioning process is complete from ipAddress().
@@ -70,7 +70,7 @@ public interface PublicIpAddress extends
 	/**
 	 * A public IP address definition allowing to specify the leaf domain label, if any
 	 */
-	public interface DefinitionWithLeafDomainLabel {
+	interface DefinitionWithLeafDomainLabel {
 		/**
 		 * Specifies the leaf domain label to associate with this public IP address. The fully qualified domain name (FQDN) 
 		 * will be constructed automatically by appending the rest of the domain to this label.
@@ -89,7 +89,7 @@ public interface PublicIpAddress extends
 	/**
 	 * A public IP address definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		Provisionable<PublicIpAddress>,
 		GroupResourceBase.DefinitionWithTags<DefinitionProvisionable>,
 		DefinitionWithLeafDomainLabel,

--- a/src/com/microsoft/azure/shortcuts/resources/ResourceGroup.java
+++ b/src/com/microsoft/azure/shortcuts/resources/ResourceGroup.java
@@ -44,7 +44,7 @@ public interface ResourceGroup extends
 	/**
 	 * A new blank resource group definition
 	 */
-	public interface DefinitionBlank {
+	interface DefinitionBlank {
 		DefinitionProvisionable withRegion(String regionName);
 		DefinitionProvisionable withRegion(Region region);
 	}
@@ -53,7 +53,7 @@ public interface ResourceGroup extends
 	/**
 	 * A new resource group definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		Provisionable<ResourceGroup> {
 		
 		DefinitionProvisionable withTags(Map<String, String> tags);
@@ -64,7 +64,7 @@ public interface ResourceGroup extends
 	/**
 	 * An existing resource group modification request ready to be applied in the cloud
 	 */
-	public interface Update extends 
+	interface Update extends
 		UpdateBlank, 
 		Updatable<Update> {
 	}
@@ -73,7 +73,7 @@ public interface ResourceGroup extends
 	/**
 	 * A blank modification request for an existing resource group
 	 */
-	public interface UpdateBlank extends 
+	interface UpdateBlank extends
 		Deletable, 
 		Taggable<Update>  {
 	}

--- a/src/com/microsoft/azure/shortcuts/resources/Size.java
+++ b/src/com/microsoft/azure/shortcuts/resources/Size.java
@@ -33,7 +33,7 @@ public interface Size extends
 	Type toSizeType();
 
 	
-	public enum Type {
+	enum Type {
 		BASIC_A0(VirtualMachineSizeTypes.BASIC_A0),
 		BASIC_A1(VirtualMachineSizeTypes.BASIC_A1),
 		BASIC_A2(VirtualMachineSizeTypes.BASIC_A2),

--- a/src/com/microsoft/azure/shortcuts/resources/StorageAccount.java
+++ b/src/com/microsoft/azure/shortcuts/resources/StorageAccount.java
@@ -40,29 +40,29 @@ public interface StorageAccount extends
 	/**
 	 * @return The URL of the primary blob endpoint
 	 */
-	public URL primaryBlobEndpoint();
+	URL primaryBlobEndpoint();
 	
 	/**
 	 * @return The type of the storage account
 	 */
-	public AccountType accountType();
+	AccountType accountType();
 	
 	/**
 	 * A new blank storage account definition
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		GroupResourceBase.DefinitionWithRegion<DefinitionWithGroup> { }
 	
 	/**
-	 * A new storage account definition allowing to specifiy the resource group to put it in
+	 * A new storage account definition allowing to specify the resource group to put it in
 	 */
-	public interface DefinitionWithGroup extends
+	interface DefinitionWithGroup extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionProvisionable> {}
 	
 	/**
 	 * A new storage account definition with sufficient input parameters specified already to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		GroupResourceBase.DefinitionWithTags<DefinitionProvisionable>,
 		Provisionable<StorageAccount> {
 		
@@ -77,7 +77,7 @@ public interface StorageAccount extends
 	/**
 	 * An existing storage account update request ready to be applied in the cloud.
 	 */
-	public interface Update extends 
+	interface Update extends
 		UpdateBlank, 
 		Updatable<Update> {
 	}
@@ -86,7 +86,7 @@ public interface StorageAccount extends
 	/**
 	 * A blank modification request for an existing storage account
 	 */
-	public interface UpdateBlank extends 
+	interface UpdateBlank extends
 		Deletable, 
 		Taggable<Update> {
 	

--- a/src/com/microsoft/azure/shortcuts/resources/VirtualMachine.java
+++ b/src/com/microsoft/azure/shortcuts/resources/VirtualMachine.java
@@ -40,47 +40,47 @@ public interface VirtualMachine extends
 	Wrapper<com.microsoft.azure.management.compute.models.VirtualMachine>,
 	Deletable {
 	
-	public String size();
-	public URI bootDiagnosticsStorage();
-	public boolean isBootDiagnosticsEnabled();
-	public URI availabilitySet();
-	public ArrayList<VirtualMachineExtension> extensions();
-	public Integer platformFaultDomain();
-	public Integer platformUpdateDomain();
-	public String remoteDesktopThumbprint();
-	public String vmAgentVersion();
-	public ArrayList<NetworkInterfaceReference> networkInterfaces();
-	public String adminUserName();
-	public String computerName();
-	public String customData();
-	public boolean isLinux();
-	public boolean isWindows();
-	public ImageReference image();
-	public List<DataDisk> dataDisks();
+	String size();
+	URI bootDiagnosticsStorage();
+	boolean isBootDiagnosticsEnabled();
+	URI availabilitySet();
+	ArrayList<VirtualMachineExtension> extensions();
+	Integer platformFaultDomain();
+	Integer platformUpdateDomain();
+	String remoteDesktopThumbprint();
+	String vmAgentVersion();
+	ArrayList<NetworkInterfaceReference> networkInterfaces();
+	String adminUserName();
+	String computerName();
+	String customData();
+	boolean isLinux();
+	boolean isWindows();
+	ImageReference image();
+	List<DataDisk> dataDisks();
 	
 	/**
 	 * Stops (powers off) the virtual machine without deallocating it. Charges keep accruing.
 	 * @throws Exception 
 	 */
-	public VirtualMachine stop() throws Exception;
+	VirtualMachine stop() throws Exception;
 
 	/** 
 	 * Restarts a virtual machine
 	 * @throws Exception
 	 */
-	public VirtualMachine restart() throws Exception;
+	VirtualMachine restart() throws Exception;
 
 	/** 
 	 * Deallocates a virtual machine. Charges no longer accrue.
 	 * @throws Exception
 	 */
-	public VirtualMachine deallocate() throws Exception;
+	VirtualMachine deallocate() throws Exception;
 
 	/**
 	 * Starts a stopped virtual machine.
 	 * @throws Exception
 	 */
-	public VirtualMachine start() throws Exception;
+	VirtualMachine start() throws Exception;
 	
 	/**
 	 * Captures a virtual machine image based on this virtual machine
@@ -89,19 +89,19 @@ public interface VirtualMachine extends
 	 * @param overwrite Determines whether to overwrite an existing image VHD, if any
 	 * @throws Exception
 	 */
-	public VirtualMachine capture(String containerName, String diskNamePrefix, boolean overwrite) throws Exception;
+	VirtualMachine capture(String containerName, String diskNamePrefix, boolean overwrite) throws Exception;
 
 	/**
 	 * Sets the state of the virtual machine as generalized, which is required for capturing an image
 	 * @throws Exception
 	 */
-	public VirtualMachine generalize() throws Exception;
+	VirtualMachine generalize() throws Exception;
 
 
 	/**
 	 * A new blank virtual machine definition requiring the first set of input parameters to be specified
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		GroupResourceBase.DefinitionWithRegion<DefinitionWithGroup> {
 		//TODO load balancers
 		//TODO network security groups
@@ -112,13 +112,13 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition requiring the resource group to be specified
 	 */
-	public interface DefinitionWithGroup extends
+	interface DefinitionWithGroup extends
 		GroupResourceBase.DefinitionWithResourceGroup<DefinitionWithNetworking> {}
 	
 	/**
 	 * A virtual machine definition allowing the networking to be specified
 	 */
-	public interface DefinitionWithNetworking extends 
+	interface DefinitionWithNetworking extends
 		DefinitionCombos.WithNewNetwork<DefinitionWithPrivateIp>,
 		DefinitionCombos.WithExistingNetwork<DefinitionWithSubnet>,
 		DefinitionCombos.WithExistingNetworkInterface<DefinitionWithAdminUsername> {}
@@ -127,26 +127,26 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition allowing a subnet with the selected virtual network to be associated with it
 	 */
-	public interface DefinitionWithSubnet extends 
+	interface DefinitionWithSubnet extends
 		DefinitionCombos.WithSubnet<DefinitionWithPrivateIp> {
 	}
 	
 	/**
 	 * A virtual machine definition allowing the primary private IP address to be specified
 	 */
-	public interface DefinitionWithPrivateIp extends 
+	interface DefinitionWithPrivateIp extends
 		DefinitionCombos.WithPrivateIpAddress<DefinitionWithPublicIp> {}
 	
 	/**
 	 * A virtual machine definition allowing the primary public IP address to be specified
 	 */
-	public interface DefinitionWithPublicIp extends
+	interface DefinitionWithPublicIp extends
 		DefinitionCombos.WithPublicIpAddress<DefinitionWithAdminUsername> {}
 	
 	/**
 	 * A virtual machine definition requiring the admin username to be specified
 	 */
-	public interface DefinitionWithAdminUsername {
+	interface DefinitionWithAdminUsername {
 		/**
 		 * @param The desired admin username for the virtual machine
 		 * @return The next stage of the VM definition
@@ -158,7 +158,7 @@ public interface VirtualMachine extends
 	/** 
 	 * A virtual machine definition requiring the admin password to be specified
 	 */
-	public interface DefinitionWithAdminPassword {
+	interface DefinitionWithAdminPassword {
 		/**
 		 * @param password The desired admin password for the virtual machine
 		 * @return The next stage of the VM definition
@@ -170,7 +170,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition allowing the selection of a base image for the virtual machine
 	 */
-	public interface DefinitionWithImage {
+	interface DefinitionWithImage {
 		DefinitionProvisionable withLatestImage(String publisher, String offer, String sku);
 		DefinitionProvisionable withImage(String publisher, String offer, String sku, String version);
 	}
@@ -179,7 +179,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition allowing to specify the size of the new virtual machine
 	 */
-	public interface DefinitionWithSize<T> {
+	interface DefinitionWithSize<T> {
 		/**
 		 * @param sizeName The name of the size for the virtual machine as text
 		 * @return A definition of the virtual machine with sufficient inputs to be provisioned
@@ -203,7 +203,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition allowing to specify a data disk to attach to the VM
 	 */
-	public interface DefinitionWithDataDisk<R> {
+	interface DefinitionWithDataDisk<R> {
 		R withNewDataDisk(int diskSizeGB);
 		R withExistingDataDisk(URI vhdUri);
 		R withExistingDataDisk(String vhdUri);
@@ -214,7 +214,7 @@ public interface VirtualMachine extends
 	 * A virtual machine definition with sufficient inputs to provision a new virtual machine in the cloud, 
 	 * but exposing additional optional inputs to specify
 	 */
-	public interface DefinitionProvisionable extends
+	interface DefinitionProvisionable extends
 		DefinitionCombos.WithStorageAccount<DefinitionProvisionable>,
 		DefinitionWithSize<DefinitionProvisionable>,
 		GroupResourceBase.DefinitionWithTags<DefinitionProvisionable>,
@@ -229,7 +229,7 @@ public interface VirtualMachine extends
 		DefinitionProvisionable withComputerName(String computerName);
 	}
 	
-	public interface UpdateBlank {
+	interface UpdateBlank {
 		
 	}
 }

--- a/src/com/microsoft/azure/shortcuts/resources/common/DefinitionCombos.java
+++ b/src/com/microsoft/azure/shortcuts/resources/common/DefinitionCombos.java
@@ -30,7 +30,7 @@ import com.microsoft.azure.shortcuts.resources.StorageAccount;
 
 public interface DefinitionCombos {
 	
-	public interface WithExistingNetwork<R> {
+	interface WithExistingNetwork<R> {
 		/**
 		 * Associates an existing virtual network with this resource
 		 * @param id The resource ID of the virtual network to associate with the resource
@@ -56,7 +56,7 @@ public interface DefinitionCombos {
 	/**
 	 * A resource definition allowing to associate a virtual network with it
 	 */
-	public interface WithNewNetwork<R> {
+	interface WithNewNetwork<R> {
 		/**
 		 * Creates a new virtual network to associate with this resource, based on the provided definition
 		 * @param networkDefinition A provisionable definition of a virtual network
@@ -84,14 +84,14 @@ public interface DefinitionCombos {
 	/**
 	 * A resource definition allowing to associate a subnet with it
 	 */
-	public interface WithSubnet<R> {
+	interface WithSubnet<R> {
 		R withSubnet(String subnetId);
 	}
 	
 	/**
 	 * A resource definition allowing to associate a storage account with this resource
 	 */
-	public interface WithStorageAccount<R> {
+	interface WithStorageAccount<R> {
 		/**
 		 * Associates an existing storage account with this resource
 		 * @param name The name of an existing storage account to associate with this resource
@@ -140,7 +140,7 @@ public interface DefinitionCombos {
 	/**
 	 * A resource definition allowing to associate an availability set with this resource
 	 */
-	public interface WithAvailabilitySet<R> {
+	interface WithAvailabilitySet<R> {
 		/**
 		 * Associates an existing availability set with this resource
 		 * @param id The resource ID of an existing availability set
@@ -194,7 +194,7 @@ public interface DefinitionCombos {
 	/**
 	 * A resource definition allowing to create a primary network interface associated with this resource
 	 */
-	public interface WithExistingNetworkInterface<R> {
+	interface WithExistingNetworkInterface<R> {
 		/**
 		 * Selects an existing network interface as the primary NIC for this resource
 		 * @param resourceId The resource ID of an existing network interface
@@ -220,7 +220,7 @@ public interface DefinitionCombos {
 	/**
 	 * A resource definition allowing to associate a primary network interface with this resource
 	 */
-	public interface WithNewNetworkInterface<R> {
+	interface WithNewNetworkInterface<R> {
 		/**
 		 * Creates a new network interface to associate with this resource as its primary NIC, in the same region and group, 
 		 * using the provided name, within the provided existing subnet, with dynamic private IP allocation enabled
@@ -251,7 +251,7 @@ public interface DefinitionCombos {
 	/**
 	 * A resource definition allowing to associate it with a public IP address
 	 */
-	public interface WithPublicIpAddress<R> {
+	interface WithPublicIpAddress<R> {
 		/**
 		 * Associates a public IP address that exists in the subscription with this resource
 		 * @param publicIpAddress An existing public IP address
@@ -291,7 +291,7 @@ public interface DefinitionCombos {
 	/**
 	 * A resource definition allowing to associate it with a private IP address within a virtual network subnet
 	 */
-	public interface WithPrivateIpAddress<R> {
+	interface WithPrivateIpAddress<R> {
 		/**
 		 * Enables dynamic private IP address allocation within the specified existing virtual network subnet as the primary subnet
 		 * @param subnet The Subnet to associate with the resource

--- a/src/com/microsoft/azure/shortcuts/resources/common/GroupResourceBase.java
+++ b/src/com/microsoft/azure/shortcuts/resources/common/GroupResourceBase.java
@@ -26,7 +26,7 @@ import com.microsoft.azure.shortcuts.resources.ResourceGroup;
 public interface GroupResourceBase extends 
 	ResourceBase {
 	
-	public String resourceGroup();
+	String resourceGroup();
 
 	/**
 	 * A resource definition allowing a resource group to be selected

--- a/src/com/microsoft/azure/shortcuts/resources/common/ResourceBase.java
+++ b/src/com/microsoft/azure/shortcuts/resources/common/ResourceBase.java
@@ -27,10 +27,10 @@ import com.microsoft.azure.shortcuts.resources.Region;
 public interface ResourceBase extends 
 	Indexable {
 	
-	public String type();
-	public String name();
-	public String region();
-	public Map<String, String> tags();
+	String type();
+	String name();
+	String region();
+	Map<String, String> tags();
 	
 	/**
 	 * A resource definition allowing a region be selected for the resource

--- a/src/com/microsoft/azure/shortcuts/resources/common/implementation/GroupableResourceBaseImpl.java
+++ b/src/com/microsoft/azure/shortcuts/resources/common/implementation/GroupableResourceBaseImpl.java
@@ -47,8 +47,8 @@ public abstract class GroupableResourceBaseImpl<
 	 * Getters
 	 *******************************************/
 	
-	@Override 
-	final public String resourceGroup() {
+	@Override
+	public final String resourceGroup() {
 		String groupNameTemp = ResourcesImpl.groupFromResourceId(this.id());
 		return (groupNameTemp == null) ? this.groupName : groupNameTemp;
 	}
@@ -58,7 +58,7 @@ public abstract class GroupableResourceBaseImpl<
 	 * Helpers
 	 * @throws Exception 
 	 **************************************************/
-	final protected ResourceGroup ensureGroup() throws Exception {
+	protected final ResourceGroup ensureGroup() throws Exception {
 		ResourceGroup group;
 		if(!this.isExistingGroup) {
 			if(this.groupName == null) {

--- a/src/com/microsoft/azure/shortcuts/resources/common/implementation/NetworkableGroupableResourceBaseImpl.java
+++ b/src/com/microsoft/azure/shortcuts/resources/common/implementation/NetworkableGroupableResourceBaseImpl.java
@@ -41,8 +41,8 @@ public abstract class NetworkableGroupableResourceBaseImpl<
 	private String subnetId;
 	protected String privateIpAddress;
 
-	
-	final protected Network ensureNetwork() throws Exception {
+
+	protected final Network ensureNetwork() throws Exception {
 		if(!this.isNetworkExisting) {
 			// Create a new virtual network
 			if(this.networkId == null) {
@@ -62,8 +62,8 @@ public abstract class NetworkableGroupableResourceBaseImpl<
 		}
 	}
 
-	
-	final protected Network.Subnet ensureSubnet(Network network) throws Exception {
+
+	protected final Network.Subnet ensureSubnet(Network network) throws Exception {
 		if(network == null) {
 			return null;
 		} else if(this.subnetId != null) {
@@ -79,33 +79,33 @@ public abstract class NetworkableGroupableResourceBaseImpl<
 	 * WithNetwork* Implementation
 	 ***********************************************************/
 	@SuppressWarnings("unchecked")
-	final public WRAPPERIMPL withExistingNetwork(String id) {
+	public final WRAPPERIMPL withExistingNetwork(String id) {
 		this.isNetworkExisting = true;
 		this.networkId = id;
 		return (WRAPPERIMPL)this;
 	}
 
-	final public WRAPPERIMPL withExistingNetwork(Network network) {
+	public final WRAPPERIMPL withExistingNetwork(Network network) {
 		return this.withExistingNetwork(network.id());
 	}
 
-	final public WRAPPERIMPL withExistingNetwork(VirtualNetwork network) {
+	public final WRAPPERIMPL withExistingNetwork(VirtualNetwork network) {
 		return this.withExistingNetwork(network.getId());
 	}
 
 	@SuppressWarnings("unchecked")
-	final public WRAPPERIMPL withNewNetwork(String name, String addressSpace) {
+	public final WRAPPERIMPL withNewNetwork(String name, String addressSpace) {
 		this.isNetworkExisting = false;
 		this.networkId = name;
 		this.networkCidr = addressSpace;
 		return (WRAPPERIMPL) this;
 	}
 
-	final public WRAPPERIMPL withNewNetwork(Network.DefinitionProvisionable networkDefinition) throws Exception {
+	public final WRAPPERIMPL withNewNetwork(Network.DefinitionProvisionable networkDefinition) throws Exception {
 		return this.withExistingNetwork(networkDefinition.provision());
 	}
 
-	final public WRAPPERIMPL withNewNetwork(String addressSpace) {
+	public final WRAPPERIMPL withNewNetwork(String addressSpace) {
 		return this.withNewNetwork((String)null, addressSpace);
 	}
 	
@@ -114,7 +114,7 @@ public abstract class NetworkableGroupableResourceBaseImpl<
 	 * WithSubnet implementation
 	 ********************************************************/
 	@SuppressWarnings("unchecked")
-	final public WRAPPERIMPL withSubnet(String subnetId) {
+	public final WRAPPERIMPL withSubnet(String subnetId) {
 		this.subnetId = subnetId;
 		return (WRAPPERIMPL)this;
 	}
@@ -123,12 +123,12 @@ public abstract class NetworkableGroupableResourceBaseImpl<
 	/*******************************************************
 	 * WithPrivateIpAddress implementation
 	 *******************************************************/
-	final public WRAPPERIMPL withPrivateIpAddressDynamic() {
+	public final WRAPPERIMPL withPrivateIpAddressDynamic() {
 		return this.withPrivateIpAddressStatic(null);
 	}
 	
 	@SuppressWarnings("unchecked")
-	final public WRAPPERIMPL withPrivateIpAddressStatic(String staticPrivateIpAddress) {
+	public final WRAPPERIMPL withPrivateIpAddressStatic(String staticPrivateIpAddress) {
 		this.privateIpAddress = staticPrivateIpAddress;
 		return (WRAPPERIMPL)this;
 	}

--- a/src/com/microsoft/azure/shortcuts/resources/common/implementation/PublicIpGroupableResourceBaseImpl.java
+++ b/src/com/microsoft/azure/shortcuts/resources/common/implementation/PublicIpGroupableResourceBaseImpl.java
@@ -46,9 +46,9 @@ public abstract class PublicIpGroupableResourceBaseImpl<
 		this.publicIpAddressId = resourceId;
 		return (TI)this;
 	}
-	
-	
-	final protected PublicIpAddress ensurePublicIpAddress() throws Exception {
+
+
+	protected final PublicIpAddress ensurePublicIpAddress() throws Exception {
 		if(!this.isPublicIpAddressExisting) {
 			// Create a new public IP
 			if(this.publicIpAddressDns == null) {
@@ -75,26 +75,26 @@ public abstract class PublicIpGroupableResourceBaseImpl<
 	/*****************************************************
 	 * WithPublicIpAddress implementation
 	 *****************************************************/
-	final public TI withExistingPublicIpAddress(com.microsoft.azure.management.network.models.PublicIpAddress publicIpAddress) {
+	public final TI withExistingPublicIpAddress(com.microsoft.azure.management.network.models.PublicIpAddress publicIpAddress) {
 		return this.withExistingPublicIpAddress((publicIpAddress != null) ? publicIpAddress.getId() : null);
 	}
 
-	final public TI withExistingPublicIpAddress(PublicIpAddress publicIpAddress) {
+	public final TI withExistingPublicIpAddress(PublicIpAddress publicIpAddress) {
 		return this.withExistingPublicIpAddress((publicIpAddress != null) ? publicIpAddress.id() : null);
 	}
 
-	final public TI withNewPublicIpAddress() {
+	public final TI withNewPublicIpAddress() {
 		return this.withNewPublicIpAddress(null);
 	}
 
 	@SuppressWarnings("unchecked")
-	final public TI withNewPublicIpAddress(String leafDnsLabel) {
+	public final TI withNewPublicIpAddress(String leafDnsLabel) {
 		this.isPublicIpAddressExisting = false;
 		this.publicIpAddressDns = (leafDnsLabel == null) ? null : leafDnsLabel.toLowerCase();
 		return (TI) this;
 	}
 
-	final public TI withoutPublicIpAddress() {
+	public final TI withoutPublicIpAddress() {
 		return this.withExistingPublicIpAddress((PublicIpAddress)null);
 	}
 }

--- a/src/com/microsoft/azure/shortcuts/services/CloudService.java
+++ b/src/com/microsoft/azure/shortcuts/services/CloudService.java
@@ -47,7 +47,7 @@ public interface CloudService extends
 	/**
 	 * A cloud service definition requiring a region to be specified
 	 */
-	public interface DefinitionWithRegion<T> {
+	interface DefinitionWithRegion<T> {
 		T withRegion(String region);
 		T withRegion(Region region);
 	}
@@ -55,14 +55,14 @@ public interface CloudService extends
 	/** 
 	 * A cloud service definition requiring an affinity group to be specified
 	 */
-	public interface DefinitionWithAffinityGroup<T> {
+	interface DefinitionWithAffinityGroup<T> {
 		T withAffinityGroup(String affinityGroup);
 	}
 	
 	/**
 	 * A new blank cloud service definition
 	 */
-	public interface DefinitionBlank extends
+	interface DefinitionBlank extends
 		DefinitionWithRegion<DefinitionProvisionable>,
 		DefinitionWithAffinityGroup<DefinitionProvisionable> {
 	}
@@ -70,28 +70,28 @@ public interface CloudService extends
 	/** 
 	 * A cloud service definition requiring a description to be specified
 	 */
-	public interface DefinitionWithDescription<T> {
-		public T withDescription(String description);
+	interface DefinitionWithDescription<T> {
+		T withDescription(String description);
 	}
 
 	/** 
 	 * A cloud service definition requiring a label to be specified
 	 */
-	public interface DefinitionWithLabel<T> {
-		public T withLabel(String label);
+	interface DefinitionWithLabel<T> {
+		T withLabel(String label);
 	}
 
 	/** 
 	 * A cloud service definition requiring a reverse DNS fully qualified domain name to be specified
 	 */
-	public interface DefinitionWithReverseDnsFqdn<T> {
-		public T withReverseDnsFqdn(String fqdn);
+	interface DefinitionWithReverseDnsFqdn<T> {
+		T withReverseDnsFqdn(String fqdn);
 	}
 
 	/**
 	 * A new cloud service definition with sufficient settings to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		DefinitionWithDescription<DefinitionProvisionable>,
 		DefinitionWithLabel<DefinitionProvisionable>,
 		DefinitionWithReverseDnsFqdn<DefinitionProvisionable>,
@@ -101,18 +101,18 @@ public interface CloudService extends
 	/**
 	 * An existing cloud service update request ready to applied in the cloud
 	 */
-	public interface Update extends UpdateBlank, Updatable<Update> {
+	interface Update extends UpdateBlank, Updatable<Update> {
 	}
 	
 	
 	/**
 	 * A blank existing cloud service update request
 	 */
-	public interface UpdateBlank extends 
+	interface UpdateBlank extends
 		Deletable {
 		
-		public Update withDescription(String description);
-		public Update withReverseDnsFqdn(String fqdn);
-		public Update withLabel(String label);
+		Update withDescription(String description);
+		Update withReverseDnsFqdn(String fqdn);
+		Update withLabel(String label);
 	}
 }

--- a/src/com/microsoft/azure/shortcuts/services/Network.java
+++ b/src/com/microsoft/azure/shortcuts/services/Network.java
@@ -42,7 +42,7 @@ public interface Network extends
 	Map<String, Subnet> subnets() throws Exception;
 	String state() throws Exception;
 	
-	public interface Subnet extends Indexable {	
+	interface Subnet extends Indexable {
 		String addressPrefix();
 		String networkSecurityGroup();
 	}
@@ -50,14 +50,14 @@ public interface Network extends
 	/**
 	 * A new blank network definition
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		DefinitionWithRegion<DefinitionWithAddressSpace> {
 	}
 	
 	/**
 	 * A virtual network definition requiring a region to be specified
 	 */
-	public interface DefinitionWithRegion<T> {
+	interface DefinitionWithRegion<T> {
 		T withRegion(String region);
 		T withRegion(Region region);		
 	}
@@ -65,14 +65,14 @@ public interface Network extends
 	/**
 	 * A virtual network definition requiring a new subnet to be specified
 	 */
-	public interface DefinitionWithSubnet<T> {
+	interface DefinitionWithSubnet<T> {
 		T withSubnet(String name, String cidr);		
 	}
 	
 	/**
 	 * A new network definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		DefinitionWithSubnet<DefinitionProvisionable>,
 		Provisionable<UpdateBlank> {
 	}
@@ -80,7 +80,7 @@ public interface Network extends
 	/**
 	 * A new network definition requiring the CIDR input parameter to be specified
 	 */
-	public interface DefinitionWithAddressSpace {
+	interface DefinitionWithAddressSpace {
 		DefinitionProvisionable withAddressSpace(String cidr);
 	}
 	
@@ -88,7 +88,7 @@ public interface Network extends
 	/**
 	 * A blank update request for an existing network
 	 */
-	public interface UpdateBlank extends Deletable {
+	interface UpdateBlank extends Deletable {
 		// TODO?
 	}
 	
@@ -96,7 +96,7 @@ public interface Network extends
 	/**
 	 * An existing network update request ready to be applied in the cloud
 	 */
-	public interface Update extends UpdateBlank, Updatable<Update> {
+	interface Update extends UpdateBlank, Updatable<Update> {
 	}
 
 }

--- a/src/com/microsoft/azure/shortcuts/services/StorageAccount.java
+++ b/src/com/microsoft/azure/shortcuts/services/StorageAccount.java
@@ -55,7 +55,7 @@ public interface StorageAccount extends
 	/**
 	 * A storage account definition requiring the region (location) to be specified
 	 */
-	public interface DefinitionWithRegion<T> {
+	interface DefinitionWithRegion<T> {
 		T withRegion(String region);
 		T withRegion(Region region);		
 	}
@@ -63,35 +63,35 @@ public interface StorageAccount extends
 	/**
 	 * A new blank storage account definition
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		DefinitionWithRegion<DefinitionProvisionable> {
 	}
 	
 	/**
 	 * A storage account definition requring the label to be specified
 	 */
-	public interface DefinitionWithLabel<T> {
+	interface DefinitionWithLabel<T> {
 		T withLabel(String label);
 	}
 	
 	/**
 	 * A storage account definition requiring the storage type to be specified
 	 */
-	public interface DefinitionWithType<T> {
+	interface DefinitionWithType<T> {
 		T withType(String type);
 	}
 
 	/**
 	 * A storage account definition requiring the description to be specified
 	 */
-	public interface DefinitionWithDescription<T> {
+	interface DefinitionWithDescription<T> {
 		T withDescription(String description);
 	}
 	
 	/**
 	 * A storage account definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		DefinitionWithType<DefinitionProvisionable>,
 		DefinitionWithLabel<DefinitionProvisionable>,
 		DefinitionWithDescription<DefinitionProvisionable>,
@@ -102,14 +102,14 @@ public interface StorageAccount extends
 	/**
 	 * An existing storage account update ready to be applied in the cloud
 	 */
-	public interface Update extends UpdateBlank, Updatable<Update> {
+	interface Update extends UpdateBlank, Updatable<Update> {
 	}
 
 	
 	/**
 	 * A blank update request for an existing storage account
 	 */
-	public interface UpdateBlank extends Deletable {
+	interface UpdateBlank extends Deletable {
 		Update withType(String type);
 		Update withDescription(String description);
 		Update withLabel(String label);

--- a/src/com/microsoft/azure/shortcuts/services/VirtualMachine.java
+++ b/src/com/microsoft/azure/shortcuts/services/VirtualMachine.java
@@ -66,7 +66,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition requiring a region (location) to be specified 
 	 */
-	public interface DefinitionWithRegion<T> {
+	interface DefinitionWithRegion<T> {
 		T withRegion(String region);
 		T withRegion(Region region);
 	}
@@ -74,7 +74,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition requiring an existing virtual network to be specified
 	 */
-	public interface DefinitionWithExistingNetwork<T> {
+	interface DefinitionWithExistingNetwork<T> {
 		T withExistingNetwork(String network);
 		T withExistingNetwork(Network network);		
 	}
@@ -83,7 +83,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition requiring an existing cloud service to be specified
 	 */
-	public interface DefinitionWithExistingCloudService<T> {
+	interface DefinitionWithExistingCloudService<T> {
 		T withExistingCloudService(String serviceName);
 		T withExistingCloudService(CloudService cloudService);
 		T withExistingCloudService(HostedService hostedService);
@@ -92,7 +92,7 @@ public interface VirtualMachine extends
 	/**
 	 * A new blank virtual machine definition requiring the initial required set of parameters to be specified
 	 */
-	public interface DefinitionBlank extends 
+	interface DefinitionBlank extends
 		DefinitionWithRegion<DefinitionWithSize>,
 		DefinitionWithExistingNetwork<DefinitionWithSize>,
 		DefinitionWithExistingCloudService<DefinitionWithSize> {
@@ -102,7 +102,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition requiring a TCP endpoint to be specified
 	 */
-	public interface DefinitionWithTcpEndpoint<T> {
+	interface DefinitionWithTcpEndpoint<T> {
 		T withTcpEndpoint(int publicPort);
 		T withTcpEndpoint(int publicPort, int privatePort);
 		T withTcpEndpoint(int publicPort, int privatePort, String name);		
@@ -111,28 +111,28 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition requiring the presence of a guest agent to be specified
 	 */
-	public interface DefinitionWithGuestAgent<T> {
+	interface DefinitionWithGuestAgent<T> {
 		T withGuestAgent(boolean enabled);		
 	}
 	
 	/**
 	 * A virtual machine definition requiring a deployment name to be specified
 	 */
-	public interface DefinitionWithDeployment<T> {
+	interface DefinitionWithDeployment<T> {
 		T withDeployment(String name);
 	}
 	
 	/**
 	 * A virtual machine definition requiring a deployment label to be specified
 	 */
-	public interface DefinitionWithDeploymentLabel<T> {
+	interface DefinitionWithDeploymentLabel<T> {
 		T withDeploymentLabel(String label);
 	}
 
 	/**
 	 * A virtual machine definition requiring an existing storage account to specified
 	 */
-	public interface DefinitionWithExistingStorageAccount<T> {
+	interface DefinitionWithExistingStorageAccount<T> {
 		T withExistingStorageAccount(String name);
 		T withExistingStorageAccount(StorageAccount account);
 		T withExistingStorageAccount(com.microsoft.windowsazure.management.storage.models.StorageAccount account);
@@ -141,7 +141,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition requiring an new cloud service to be specified
 	 */
-	public interface DefinitionWithNewCloudService<T> {
+	interface DefinitionWithNewCloudService<T> {
 		T withNewCloudService(String name);
 		T withNewCloudService(CloudService.DefinitionProvisionable cloudServiceDefinition);
 	}
@@ -149,7 +149,7 @@ public interface VirtualMachine extends
 	/**
 	 * A virtual machine definition requiring a subnet to be specified
 	 */
-	public interface DefinitionWithSubnet<T> {
+	interface DefinitionWithSubnet<T> {
 		T withSubnet(String subnet);
 	}
 
@@ -157,7 +157,7 @@ public interface VirtualMachine extends
 	/**
 	 * A new virtual machine definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionProvisionable extends 
+	interface DefinitionProvisionable extends
 		DefinitionWithTcpEndpoint<DefinitionProvisionable>,
 		DefinitionWithGuestAgent<DefinitionProvisionable>,
 		DefinitionWithDeployment<DefinitionProvisionable>,
@@ -172,14 +172,14 @@ public interface VirtualMachine extends
 	/**
 	 * A new virtual machine definition requiring the host name to be specified
 	 */
-	public interface DefinitionWithHostName<T> {
+	interface DefinitionWithHostName<T> {
 		T withHostName(String name) throws Exception;
 	}
 	
 	/**
 	 * A new Linux virtual machine definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionLinuxProvisionable extends 
+	interface DefinitionLinuxProvisionable extends
 		DefinitionWithHostName<DefinitionLinuxProvisionable>,
 		DefinitionProvisionable {
 	}
@@ -187,21 +187,21 @@ public interface VirtualMachine extends
 	/** 
 	 * A new virtual machine definition requiring the enablement of AutoUpdate to be specified
 	 */
-	public interface DefinitionWithAutoUpdate<T> {
+	interface DefinitionWithAutoUpdate<T> {
 		T withAutoUpdate(boolean autoUpdate);
 	}
 
 	/** 
 	 * A new virtual machine definition requiring the computer name to be specified
 	 */
-	public interface WithComputerName<T> {
+	interface WithComputerName<T> {
 		T withComputerName(String name) throws Exception;
 	}
 
 	/**
 	 * A new Windows virtual machine definition with sufficient input parameters specified to be provisioned in the cloud
 	 */
-	public interface DefinitionWindowsProvisionable extends 
+	interface DefinitionWindowsProvisionable extends
 		DefinitionWithAutoUpdate<DefinitionWindowsProvisionable>,
 		WithComputerName<DefinitionWindowsProvisionable>,
 		DefinitionProvisionable {
@@ -210,7 +210,7 @@ public interface VirtualMachine extends
 	/**
 	 * A new virtual machine definition requiring the admin username to be specified
 	 */
-	public interface DefinitionWithAdminUsername {
+	interface DefinitionWithAdminUsername {
 		DefinitionWithAdminPassword withAdminUsername(String name); 
 	}
 	
@@ -218,7 +218,7 @@ public interface VirtualMachine extends
 	/**
 	 * A new virtual machine definition requiring the admin password to be specified
 	 */
-	public interface DefinitionWithAdminPassword {
+	interface DefinitionWithAdminPassword {
 		DefinitionWithImage withAdminPassword(String password);
 	}
 	
@@ -226,7 +226,7 @@ public interface VirtualMachine extends
 	/**
 	 * A new virtual machine definition requiring a Linux or Windows images to be specified
 	 */
-	public interface DefinitionWithImage {
+	interface DefinitionWithImage {
 		DefinitionLinuxProvisionable withLinuxImage(String image);		
 		DefinitionWindowsProvisionable withWindowsImage(String image);
 	}
@@ -235,7 +235,7 @@ public interface VirtualMachine extends
 	/**
 	 * A new virtual machine definition requiring a VM size to be specified
 	 */
-	public interface DefinitionWithSize {
+	interface DefinitionWithSize {
 		DefinitionWithAdminUsername withSize(String size);
 	}
 
@@ -243,14 +243,14 @@ public interface VirtualMachine extends
 	/**
 	 * An existing virtual machine update request ready to be applied in the cloud
 	 */
-	public interface Update extends UpdateBlank, Updatable<Update> {
+	interface Update extends UpdateBlank, Updatable<Update> {
 	}
 	
 
 	/**
 	 * A blank update request for an existing virtual machine
 	 */
-	public interface UpdateBlank extends Deletable {
+	interface UpdateBlank extends Deletable {
 	}
 }
 

--- a/src/com/microsoft/azure/shortcuts/services/implementation/Azure.java
+++ b/src/com/microsoft/azure/shortcuts/services/implementation/Azure.java
@@ -165,7 +165,7 @@ public class Azure {
 	
 	
 	// Returns the management client, creating it as needed
-	ManagementClient managementClient() {
+	public ManagementClient managementClient() {
 		if(this.management == null) {
 			this.management = ManagementService.create(configuration);
 		}
@@ -175,7 +175,7 @@ public class Azure {
 	
 	
 	// Returns the compute management client, creating it as needed
-	ComputeManagementClient computeManagementClient() {
+	public ComputeManagementClient computeManagementClient() {
 		if(this.compute == null) {
 			this.compute = ComputeManagementService.create(configuration);
 		}
@@ -185,7 +185,7 @@ public class Azure {
 	
 	
 	// Returns the storage management client, creating it as needed
-	StorageManagementClient storageManagementClient() {
+	public StorageManagementClient storageManagementClient() {
 		if(this.storage == null) {
 			this.storage = StorageManagementService.create(configuration);
 		}
@@ -195,7 +195,7 @@ public class Azure {
 	
 	
 	// Returns the network management client, creating as needed
-	NetworkManagementClient networkManagementClient() {
+	public NetworkManagementClient networkManagementClient() {
 		if(this.networking == null) {
 			this.networking = NetworkManagementService.create(configuration);
 		}


### PR DESCRIPTION
- Fix Typos.
- Remove useless public modifier from interface methods.
- Ensure standard convention between order modifiers on method definitions.
- Ensure Utils class cannot be accidentally instantiated.
